### PR TITLE
remove rounding in ltdb data reader

### DIFF
--- a/osnap/data/data.py
+++ b/osnap/data/data.py
@@ -258,7 +258,7 @@ def read_ltdb(sample, fullcount):
     for row in dictionary['formula'].dropna().tolist():
         df.eval(row, inplace=True)
 
-    df = df.round(0)
+    # df = df.round(0)
 
     keeps = df.columns[df.columns.isin(dictionary['variable'].tolist() +
                                        ['year'])]


### PR DESCRIPTION
Remove rounding to integers in ltdb data reader. Address https://github.com/spatialucr/osnap/issues/54

